### PR TITLE
fixing setup.py for pip install 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ecg_qc = EcgQc()
 Default parameters:
 
 ```python
-ecg_qc = EcgQc(model='rfc_norm_2s.pkl',
+ecg_qc = EcgQc(model_file='rfc_norm_2s.pkl',
                sampling_frequency=256,
                normalized=True)
 ```
@@ -95,7 +95,7 @@ Computing SQIs before making prediction:
 ```python
 ecg_data = [1905.72, ... -150.75995323, -134.14559104] # ECG values with same sampling frequency as class declaration
 
-sqi_scores = ecg_qc.compute_sqi_score(ecg_data)
+sqi_scores = ecg_qc.compute_sqi_scores(ecg_data)
 signal_quality = ecg_qc.predict_quality(sqi_scores)
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     url="https://github.com/Aura-healthcare/ecg_qc",
-    packages=setuptools.find_packages("ecg_qc/*", exclude=["tests"]),
+    # setuptools.find_packages("ecg_qc/*", exclude=["tests"]),
+    packages=['ecg_qc'],
+    ackage_dir={'ecg_qc': 'ecg_qc'},
     python_requires='>=3.6',
     install_requires=[
         "biosppy>=0.6.1",

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     url="https://github.com/Aura-healthcare/ecg_qc",
-    # setuptools.find_packages("ecg_qc/*", exclude=["tests"]),
     packages=['ecg_qc'],
-    ackage_dir={'ecg_qc': 'ecg_qc'},
     python_requires='>=3.6',
     install_requires=[
         "biosppy>=0.6.1",


### PR DESCRIPTION
Small setup.py fix. 

The current version of setup.py will look inside of the ecg_qc for modules whereas we actually want it to install ecg_qc as a module. 

Thanks for the nice repo!